### PR TITLE
gunicorn has no "--debug" flag

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ After=vboxservice.service
 Type=simple
 User=vagrant
 WorkingDirectory=/vagrant
-ExecStart=/home/vagrant/venv/bin/gunicorn --debug --log-level debug ps1auth.wsgi:application --reload
+ExecStart=/home/vagrant/venv/bin/gunicorn --log-level debug ps1auth.wsgi:application --reload
 EnvironmentFile=-/home/vagrant/ps1auth.conf
 
 [Install]


### PR DESCRIPTION
Pretty much as it says on the tin. :) At least 19.2.0 doesn't have it.

This prevents the Vagrant setup from working out of the box. 