### PR TITLE
Requires staff level to grant member points

### DIFF
--- a/memberpoint/views.py
+++ b/memberpoint/views.py
@@ -55,5 +55,5 @@ class MemberPointFormView(FormView):
             return self.form_invalid(form)
 
     @method_decorator(staff_member_required)
-    def dispath(self, *args, **kwargs):
+    def dispatch(self, *args, **kwargs):
         return super(MemberPointFormView, self).dispath(*args, **kwargs)


### PR DESCRIPTION
A typo (dispath versus dispatch) failed to prevent access to granting
member poitns.  Fixes #66.