### PR TITLE
Move quorum logic from view to model

### DIFF
--- a/member_management/models.py
+++ b/member_management/models.py
@@ -32,7 +32,7 @@ class PersonManager(models.Manager):
 
     def quorum(self):
         full_members = self.get_queryset().filter(membership_status='full_member').count()
-        return max(int(ceil(float(full_members / 3))), 1)
+        return max(int(ceil(full_members / 3)), 1)
 
 
 @reversion.register

--- a/member_management/models.py
+++ b/member_management/models.py
@@ -1,3 +1,4 @@
+from math import ceil
 from django.db import models
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -28,6 +29,11 @@ class PersonManager(models.Manager):
 
     def members(self):
         return self.get_queryset().filter(Q(membership_status='full_member')|Q(membership_status='starving_hacker'))
+
+    def quorum(self):
+        full_members = self.get_queryset().filter(membership_status='full_member').count()
+        return max(int(ceil(float(full_members / 3))), 1)
+
 
 @reversion.register
 class Person(models.Model):

--- a/member_management/tests.py
+++ b/member_management/tests.py
@@ -3,6 +3,7 @@ from .models import Person
 from django.test import Client, TestCase
 from pprint import pprint
 
+
 class PersonTest(TestCase):
 
     def setUp(self):
@@ -44,3 +45,29 @@ class PersonTest(TestCase):
 
         #clieanup
         PS1User.objects.delete_user(lonely)
+
+
+class QuorumTest(TestCase):
+
+    def test_no_members(self):
+        self.assertEqual(1, Person.objects.quorum())
+
+    def test_no_full_members(self):
+        Person.objects.create(first_name=".", last_name=".", membership_status="starving_hacker")
+        self.assertEqual(1, Person.objects.quorum())
+
+    def test_quorum(self):
+        # no members
+        self.assertEqual(1, Person.objects.quorum())
+
+        Person.objects.create(first_name="1", last_name=".", membership_status="full_member")
+        self.assertEqual(1, Person.objects.quorum())
+
+        Person.objects.create(first_name="2", last_name=".", membership_status="full_member")
+        self.assertEqual(1, Person.objects.quorum())
+
+        Person.objects.create(first_name="3", last_name=".", membership_status="full_member")
+        self.assertEqual(1, Person.objects.quorum())
+
+        Person.objects.create(first_name="4", last_name=".", membership_status="full_member")
+        self.assertEqual(2, Person.objects.quorum())

--- a/member_management/views.py
+++ b/member_management/views.py
@@ -39,7 +39,7 @@ def member_list(request):
     data['full_members'] = Person.objects.full_members().order_by('last_name')
     data['starving_hackers'] = Person.objects.starving_hackers().order_by('last_name')
     data['member_count'] = Person.objects.members().count()
-    data['quorum_count'] = max(int(ceil(float(data['full_members'].count() / 3))), 1)
+    data['quorum_count'] = Person.objects.quorum()
     return render(request, 'member_management/member_list.html', data)
 
 @staff_member_required


### PR DESCRIPTION
This doesn't change how quorum is counted. This moves the logic for counting quorum out of the view and in to the model. I moved the logic, and added a test to check quorums.

The quorum logic needs a little fixing, but this change is only to move the logic to a better location.

Once we have that, and a test, we can start changing other things, in relation to #92 and also for 0 members.