### PR TITLE
add manager for pending members

### DIFF
--- a/member_management/models.py
+++ b/member_management/models.py
@@ -2,7 +2,10 @@ from math import ceil
 from django.db import models
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from django.db.models import Q
+from django.db.models import (
+    Count,
+    Q,
+)
 from django.template import Context, Template
 from datetime import date
 from email.mime.application import MIMEApplication
@@ -33,6 +36,11 @@ class PersonManager(models.Manager):
     def quorum(self):
         full_members = self.get_queryset().filter(membership_status='full_member').count()
         return max(int(ceil(full_members / 3)), 1)
+
+    def pending_members(self):
+        """Get a query of all members who need IDs Checked"""
+        members = self.get_queryset().filter(Q(membership_status='full_member')|Q(membership_status='starving_hacker'))
+        return members.annotate(c=Count("idcheck")).filter(c__lte=1)
 
 
 @reversion.register

--- a/member_management/tests.py
+++ b/member_management/tests.py
@@ -1,5 +1,8 @@
 from accounts.models import PS1User
-from .models import Person
+from .models import (
+    IDCheck,
+    Person,
+)
 from django.test import Client, TestCase
 from pprint import pprint
 
@@ -45,6 +48,21 @@ class PersonTest(TestCase):
 
         #clieanup
         PS1User.objects.delete_user(lonely)
+
+    def test_pending_count(self):
+        p1 = Person.objects.create(first_name=".", last_name=".", membership_status="starving_hacker")
+        Person.objects.create(first_name="1", last_name=".", membership_status="full_member")
+
+        # Two new members should show up pending, since they have no ID checks
+        self.assertEqual(2, Person.objects.pending_members().count())
+
+        # One member got an ID checked once, and should still show up as pending
+        IDCheck.objects.create(person=p1, user=self.user)
+        self.assertEqual(2, Person.objects.pending_members().count())
+
+        # With another ID check, that member should not show up as pending
+        IDCheck.objects.create(person=p1, user=self.user)
+        self.assertEqual(1, Person.objects.pending_members().count())
 
 
 class QuorumTest(TestCase):


### PR DESCRIPTION
The Person manager now provides a method that returns all of the Persons who need to have their IDs checked.

I want this so that I can make a view of members who need their IDs checked so that I can pull it up on Tuesdays when I'm checking IDs.